### PR TITLE
Update README.md for the Zimlet guide

### DIFF
--- a/simple/README.md
+++ b/simple/README.md
@@ -55,7 +55,7 @@ More information can be found in https://github.com/Zimbra/zm-extension-guide.
 
 You need to deploy and enable the Zimlet Sideloader on your development server. You only have to do this step once. 
 
-      sudo jyum install zimbra-zimlet-sideloader
+      sudo yum install zimbra-zimlet-sideloader
       sudo apt install zimbra-zimlet-sideloader
       su - zimbra
       zmmailboxdctl restart

--- a/simple/README.md
+++ b/simple/README.md
@@ -14,14 +14,7 @@ To follow the steps in this article you need a Zimbra test server. You also need
 
 ## Deploy Mytest back-end
 
-This article uses the `Mytest` back-end from the guide for back-end extensions at https://github.com/Zimbra/zm-extension-guide. Install a pre-compiled version to be sure you have it on your development server:
-
-      sudo rm -Rf /opt/zimbra/lib/ext/mytest
-      sudo mkdir /opt/zimbra/lib/ext/mytest
-      wget https://github.com/Zimbra/zm-extension-guide/releases/download/0.0.2/mytest.jar -O /opt/zimbra/lib/ext/mytest/mytest.jar      
-      su zimbra
-      cd /tmp
-      zmmailboxdctl restart
+This article uses the `Mytest` back-end from the guide for back-end extensions at https://github.com/Zimbra/zm-extension-guide.
 
 ## Enable multipart/form-data on Zimbra Extensions
 
@@ -62,10 +55,12 @@ More information can be found in https://github.com/Zimbra/zm-extension-guide.
 
 You need to deploy and enable the Zimlet Sideloader on your development server. You only have to do this step once. 
 
-      yum install zimbra-zimlet-sideloader
-      apt install zimbra-zimlet-sideloader
+      sudo jyum install zimbra-zimlet-sideloader
+      sudo apt install zimbra-zimlet-sideloader
       su - zimbra
       zmmailboxdctl restart
+
+If you are using a new installation of Zimbra 9 or above, you don't need to restart the mailbox server (the installer does for you).
 
 ![](screenshots/01-COS-Zimlet.png)
 *Verify that the Sideloader Zimlet is available and enabled for your Zimbra Class of Service (CoS) by logging into the Admin UI -> Home -> Configure -> Class of Service.*
@@ -84,6 +79,8 @@ As root:
       yum install nodejs
       apt install nodejs
       npm install -g @zimbra/zimlet-cli
+
+> :warning: Make sure to install nodejs version 14.x or higher.
 
 ## Zimlet CLI
 
@@ -330,7 +327,9 @@ The `mytest` item in the More menu is registered in the main index.js with these
 import createMore from "./components/more";
 const moreMenu = createMore(context, <Text id={`app.menuItem`}/>);
 ```
-`<Text>` is a helper component to get a string in the language preferred by the user. See `src/intl/en_US.json`. createMore is imported from `src/components/more/index.js` and is included here for reference:
+`<Text>` is a helper component to get a string in the language preferred by the user. See `src/intl/en_US.json`. You can apply the translated strings by the language specific files, such as `src/intl/ja.json`.
+
+createMore is imported from `src/components/more/index.js` and is included here for reference:
 
 ```javascript
 import { createElement } from 'preact';

--- a/simple/README.md
+++ b/simple/README.md
@@ -14,7 +14,13 @@ To follow the steps in this article you need a Zimbra test server. You also need
 
 ## Deploy Mytest back-end
 
-This article uses the `Mytest` back-end from the guide for back-end extensions at https://github.com/Zimbra/zm-extension-guide.
+This article uses the `Mytest` back-end from the guide for back-end extensions at https://github.com/Zimbra/zm-extension-guide. Install a pre-compiled version to be sure you have it on your development server:
+
+      sudo rm -Rf /opt/zimbra/lib/ext/mytest
+      sudo mkdir /opt/zimbra/lib/ext/mytest
+      sudo wget https://github.com/Zimbra/zm-extension-guide/releases/download/0.0.8/mytest.jar -O /opt/zimbra/lib/ext/mytest/mytest.jar
+      su - zimbra
+      zmmailboxdctl restart
 
 ## Enable multipart/form-data on Zimbra Extensions
 

--- a/simple/src/intl/ja.json
+++ b/simple/src/intl/ja.json
@@ -1,0 +1,6 @@
+{
+	"app": {
+		"menuItem": "テストZimlet"
+      }
+}
+


### PR DESCRIPTION
* Removed the description about the pre-compiled version of mytest.jar.  The description is not applicable right now; there is no mytest.jar in the specified directory, and people have to compile it themselves.
* The zimbra-zimlet-sideloader package should be installed under the root privileges
* Explicitly described the nodejs version.  As for now, I tested and found that minimumly node -v should be v14.21.1 (on Ubuntu)
* Added a description about some L10N modification, and put a sample L10N file in Japanese.